### PR TITLE
Disable hit test on KeyboardAvoidingView

### DIFF
--- a/Sources/Placement/Layouting/PlacementKeyboardAvoidingModifier.swift
+++ b/Sources/Placement/Layouting/PlacementKeyboardAvoidingModifier.swift
@@ -113,6 +113,9 @@ struct PlacementKeyboardAvoidingModifier<L: PlacementLayout>: ViewModifier {
     
     func body(content: Content) -> some View {
         content
-            .background(KeyboardAvoidingView<L>(keyboardFrame: $keyboardFrame))
+            .background(
+              KeyboardAvoidingView<L>(keyboardFrame: $keyboardFrame)
+                .allowsHitTesting(false)
+            )
     }
 }


### PR DESCRIPTION
The `KeyboardAvoidingView` blocked user interaction for any background view