### PR TITLE
Fix PlacementThatFits behavior inside HStacks 

### DIFF
--- a/Sources/DemoApp/DemoViews/PlacementThatFitsDemo.swift
+++ b/Sources/DemoApp/DemoViews/PlacementThatFitsDemo.swift
@@ -15,25 +15,52 @@ struct PlacementThatFitsDemo: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                PlacementThatFits(prefersViewThatFits: false) {
-                    Button("Some longer text that wont fit initially") {
-                      print("tap index 0")
-                    }.onAppear(perform: {
-                      print("did appear index 0")
-                    })
-                    Button("A button") {
-                      print("tap index 1")
-                    }.onAppear(perform: {
-                      print("did appear index 1")
-                    })
-                }
-                .border(.red)
-                .frame(maxWidth: changeContainerWidth ? .infinity : 150)
-                
+                Text("Layout below uses SwiftUI.ViewThatFits (on iOS 16)")
+                    .fontWeight(.semibold)
+                Demo(changeContainerWidth: changeContainerWidth, prefersViewThatFits: true)
+
+                Text("Layout below uses Placement")
+                    .fontWeight(.semibold)
+                Demo(changeContainerWidth: changeContainerWidth, prefersViewThatFits: false)
+
                 Button("Change container width") {
                     changeContainerWidth.toggle()
                 }
             }.frame(maxWidth: .infinity)
         }
+    }
+}
+
+private struct Demo: View {
+    var changeContainerWidth: Bool
+    var prefersViewThatFits: Bool
+
+    var body: some View {
+        PlacementThatFits(prefersViewThatFits: prefersViewThatFits) {
+            Button("Some longer text that wont fit initially") {
+              print("tap index 0")
+            }.onAppear(perform: {
+              print("did appear index 0")
+            })
+            Button("A button") {
+              print("tap index 1")
+            }.onAppear(perform: {
+              print("did appear index 1")
+            })
+        }
+        .border(.red)
+        .frame(maxWidth: changeContainerWidth ? .infinity : 150)
+
+        HStack {
+            Text("Leading view")
+            Color.red
+                .frame(width: 1)
+            PlacementThatFits(prefersViewThatFits: prefersViewThatFits) {
+                Text("Trailing view with long text")
+                Text("Trailing view")
+            }
+        }
+        .border(.red)
+        .frame(maxWidth: changeContainerWidth ? .infinity : 150)
     }
 }

--- a/Sources/DemoApp/DemoViews/PlacementThatFitsDemo.swift
+++ b/Sources/DemoApp/DemoViews/PlacementThatFitsDemo.swift
@@ -62,5 +62,12 @@ private struct Demo: View {
         }
         .border(.red)
         .frame(maxWidth: changeContainerWidth ? .infinity : 150)
+
+
+        PlacementThatFits(prefersViewThatFits: prefersViewThatFits) {
+            Color.yellow
+            Color.green
+        }
+        .frame(maxWidth: changeContainerWidth ? .infinity : 5)
     }
 }

--- a/Sources/Placement/Layouting/Coordinator.swift
+++ b/Sources/Placement/Layouting/Coordinator.swift
@@ -130,12 +130,15 @@ class Coordinator<L: PlacementLayout>: ObservableObject {
                 },
                 getSizeThatFits: { size in
                     let hostingController = self.makeHostingController(id: child.id)
-                    hostingController.rootView = AnyView(child)
-                                                            
+
+                    // Fix the view in its ideal size if the corresponding dimension
+                    // in the proposal is unspecified
+                    hostingController.rootView = AnyView(child.fixedSize(horizontal: size.width == nil, vertical: size.height == nil))
+
                     let sizeThatFits = hostingController.sizeThatFits(
                         in: CGSize(
-                            width: size.width ?? UIView.layoutFittingCompressedSize.width,
-                            height: size.height ?? UIView.layoutFittingCompressedSize.height
+                            width: size.width ?? .infinity,
+                            height: size.height ?? .infinity
                         )
                     )
                                                             

--- a/Sources/Placement/PlacementThatFits/PlacementThatFitsLayout.swift
+++ b/Sources/Placement/PlacementThatFits/PlacementThatFitsLayout.swift
@@ -49,23 +49,30 @@ struct PlacementThatFitsLayout: PlacementLayout {
         
         for index in subviews.indices {
             let subview = subviews[index]
+            let idealSize = subview.sizeThatFits(.unspecified)
             let size = subview.sizeThatFits(proposal)
-                        
+
             if axes.contains(.horizontal) && axes.contains(.vertical) {
-                if size.width <= (proposal.width ?? .infinity) && size.height <= (proposal.height ?? .infinity) {
+                if idealSize.width <= (proposal.width ?? .infinity) && idealSize.height <= (proposal.height ?? .infinity) {
                     coordinator.indexToPlace = index
                     return size
                 }
             } else if axes.contains(.horizontal) {
-                if size.width <= (proposal.width ?? .infinity) {
+                if idealSize.width <= (proposal.width ?? .infinity) {
                     coordinator.indexToPlace = index
                     return size
                 }
             } else if axes.contains(.vertical) {
-                if size.height <= (proposal.height ?? .infinity) {
+                if idealSize.height <= (proposal.height ?? .infinity) {
                     coordinator.indexToPlace = index
                     return size
                 }
+            }
+
+            if index == subviews.endIndex - 1 {
+                // If none of the subviews fit, return the last one
+                coordinator.indexToPlace = index
+                return size
             }
         }
         

--- a/Sources/Placement/PlacementThatFits/PlacementThatFitsVariadicRoot.swift
+++ b/Sources/Placement/PlacementThatFits/PlacementThatFitsVariadicRoot.swift
@@ -16,7 +16,6 @@ struct PlacementThatFitsVariadicRoot: _VariadicView_MultiViewRoot {
         ForEach(children) { child in
             let index = children.firstIndex { $0.id == child.id }
             child
-                .fixedSize()
                 .modifier(PlacementThatFitsChildModifier(index: index, coordinator: coordinator))
         }
     }


### PR DESCRIPTION
This is the current behavior:
<img width="50%" src="https://github.com/user-attachments/assets/058d9e55-5fcb-4f96-bc6a-4b0be7e23ce5" />
After this fix, the `PlacementThatFits` behavior matches the behavior of `ViewThatFits`.

By the way, thank you for this library, it's awesome. I'm really glad that I'm able to support iOS 15 in my app quite easily.